### PR TITLE
button now has name and value

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -1,38 +1,30 @@
 <template>
-<div class="form-group">
-    <button @click="click" :class="classList">{{label}}</button>
-</div>
+  <div class="form-group">
+    <button @click="click" :class="classList" :name="name" :value="value">{{label}}</button>
+  </div>
 </template>
 
 <script>
 export default {
-    props: [
-        'variant',
-        'label',
-        'event',
-        'eventData'
-    ],
-    computed: {
-        classList() {
-            let variant = this.variant || 'primary';
-            return {
-                btn: true,
-                ['btn-' + variant]: true
-            }
-        }
-    },
-    methods: {
-        click() {
-            this.$emit(this.event, this.eventData)
-        }
+  props: ["variant", "label", "event", "eventData", "name", "value"],
+  computed: {
+    classList() {
+      let variant = this.variant || "primary";
+      return {
+        btn: true,
+        ["btn-" + variant]: true
+      };
     }
-
-    
-}
+  },
+  methods: {
+    click() {
+      this.$emit(this.event, this.eventData);
+    }
+  }
+};
 </script>
 
 <style lang="scss" scoped>
-
 </style>
 
 

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -29,8 +29,7 @@ export default [{
                 fontWeight: 'normal',
                 textAlign: 'left'
             },
-            inspector: [
-                {
+            inspector: [{
                     type: "FormTextArea",
                     field: "label",
                     config: {
@@ -491,7 +490,9 @@ export default [{
             config: {
                 label: "New Submit",
                 variant: 'primary',
-                event: 'submit'
+                event: 'submit',
+                name: null,
+                value: null
             },
             inspector: [{
                     type: "FormInput",
@@ -499,6 +500,22 @@ export default [{
                     config: {
                         label: "Field Label",
                         helper: "The label describes the button's text"
+                    }
+                },
+                {
+                    type: "FormInput",
+                    field: "name",
+                    config: {
+                        label: "Field Name",
+                        helper: "The name of the button"
+                    }
+                },
+                {
+                    type: "FormInput",
+                    field: "value",
+                    config: {
+                        label: "Field Value",
+                        helper: "The value being submitted"
                     }
                 },
                 {


### PR DESCRIPTION
They submit button can now be used as an approve or reject button with a name and value to submit with it.
![screen shot 2018-12-03 at 11 04 19 am](https://user-images.githubusercontent.com/29641725/49395401-331baf80-f6eb-11e8-99a5-d0f0bbe737be.png)
