### PR TITLE
Easily pass name of element to child

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -9,7 +9,7 @@
 
             <div v-else>
                 <component ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit"
-                           @pageNavigate="pageNavigate" v-bind="element.config" :is="element['component']">
+                           @pageNavigate="pageNavigate" v-bind:name="element.config.name" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
         </div>

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -9,7 +9,7 @@
 
             <div v-else>
                 <component ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit"
-                           @pageNavigate="pageNavigate" v-bind:name="element.config.name" v-bind="element.config" :is="element['component']">
+                           @pageNavigate="pageNavigate" v-bind:name="element.config.name === undefined ? element.config.name : null" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
         </div>


### PR DESCRIPTION
We need to bind the name of the element to the component so that child elements have easy access. This will be used by the File Downloader in order to specify which file should be displayed/downloaded on the renderer.