### PR TITLE
Implements color properties in form builder controls #52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-builder",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-builder",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -5,12 +5,12 @@
                 <draggable class="col-sm column-draggable" v-model="items[0]" :options="{group: {name: 'controls'}}">
                     <div class="control-item" :class="{selected: selected === element}" v-for="(element,index) in items[0]" :key="index">
                          <div v-if="element.container">
-                            <component @inspect="inspect" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
+                            <component :class="elementCssClass(element)" @inspect="inspect" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
                             <button class="delete btn btn-danger" @click="deleteItem(0, index)">x</button>
                         </div>
 
                         <div v-else>
-                            <component v-bind="element.config" :is="element['editor-component']"></component>
+                            <component :class="elementCssClass(element)" v-bind="element.config" :is="element['editor-component']"></component>
                             <div @click="inspect(element)" class="mask"></div>
                             <button class="delete btn btn-danger" @click="deleteItem(0, index)">x</button>
                         </div>
@@ -21,12 +21,12 @@
                 <draggable class="col-sm column-draggable" v-model="items[1]" :options="{group: {name: 'controls'}}">
                     <div class="control-item" :class="{selected: selected === element}" v-for="(element,index) in items[1]" :key="index">
                          <div v-if="element.container">
-                            <component @inspect="inspect" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
+                            <component :class="elementCssClass(element)" @inspect="inspect" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
                             <button class="delete btn btn-danger" @click="deleteItem(1, index)">x</button>
                         </div>
 
                         <div v-else>
-                            <component v-bind="element.config" :is="element['editor-component']"></component>
+                            <component :class="elementCssClass(element)" v-bind="element.config" :is="element['editor-component']"></component>
                             <div @click="inspect(element)" class="mask"></div>
                             <button class="delete btn btn-danger" @click="deleteItem(1, index)">x</button>
                         </div>
@@ -46,6 +46,7 @@ import MultiColumn from "../editor/multi-column";
 import FormText from "../renderer/form-text";
 import FormButton from "../renderer/form-button";
 import FormImage from "../renderer/form-image";
+import HasColorProperty from "../../mixins/HasColorProperty"
 
 import {
 FormInput,
@@ -58,6 +59,7 @@ FormInput,
 
 export default {
   name: 'MultiColumn',
+  mixins: [HasColorProperty],
   props: ["value", "selected"],
   components: {
     draggable,

--- a/src/components/inspector/color-select.vue
+++ b/src/components/inspector/color-select.vue
@@ -5,6 +5,7 @@
     </label>
     <div>
       <a v-for="option in options"
+         :key="option"
          class="btn btn-sm"
          :class="{'btn-outline-light': option.value!==value  , 'btn-outline-secondary': option.value===value}"
          @click="selectColor(option.value)">

--- a/src/components/inspector/color-select.vue
+++ b/src/components/inspector/color-select.vue
@@ -5,7 +5,7 @@
     </label>
     <div>
       <a v-for="option in options"
-         :key="option"
+         :key="option.value"
          class="btn btn-sm"
          :class="{'btn-outline-light': option.value!==value  , 'btn-outline-secondary': option.value===value}"
          @click="selectColor(option.value)">

--- a/src/components/inspector/color-select.vue
+++ b/src/components/inspector/color-select.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="form-group">
+    <label>
+      {{label}} <input type="checkbox" @click="checkColor" :checked="hasColor">
+    </label>
+    <div>
+      <a v-for="option in options"
+         class="btn btn-sm"
+         :class="{'btn-outline-light': option.value!==value  , 'btn-outline-secondary': option.value===value}"
+         @click="selectColor(option.value)">
+         <i class="fas fa-square" :class="'text-' + option.content"></i>
+      </a>
+    </div>
+    <small class="form-text text-muted">{{helper}}</small>
+  </div>
+</template>
+
+<script>
+
+  export default {
+    props: ["label", "value", "helper", "options"],
+    components: {
+    },
+    data() {
+      return {
+      };
+    },
+    computed: {
+      hasColor() {
+        return !!this.value;
+      }
+    },
+    methods: {
+      checkColor() {
+        this.hasColor ? this.$emit('input', '') : null;
+      },
+      selectColor(color) {
+        this.$emit('input', color);
+      },
+    }
+  };
+</script>
+
+<style lang="scss" scoped>
+  .image-preview {
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    height: 4em;
+    text-align: center;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -5,14 +5,14 @@
                 <div class="col">
                     <div v-for="(element,index) in items[0]" :key="index">
                         <div v-if="element.container" class="container">
-                            <component ref="container" v-model="element.items" :transientData="transientData" @submit="submit"
+                            <component :class="elementCssClass(element)" ref="container" v-model="element.items" :transientData="transientData" @submit="submit"
                                        @pageNavigate="pageNavigate" v-bind="element.config"
                                        :is="element['component']">
                             </component>
                         </div>
 
                         <div v-else>
-                            <component ref="elements" v-model="model[element.config.name]" :validationData="transientData"
+                            <component :class="elementCssClass(element)" ref="elements" v-model="model[element.config.name]" :validationData="transientData"
                                        @submit="submit" @pageNavigate="pageNavigate" v-bind="element.config"
                                        :is="element['component']" v-show="showElement[element.config.name]">
                             </component>
@@ -23,14 +23,14 @@
                 <div class="col">
                     <div v-for="(element,index) in items[1]" :key="index">
                         <div v-if="element.container" class="container">
-                            <component ref="container" v-model="element.items" :transientData="transientData" v-bind="element.config"
+                            <component :class="elementCssClass(element)" ref="container" v-model="element.items" :transientData="transientData" v-bind="element.config"
                                        @submit="submit" @pageNavigate="pageNavigate"
                                        :is="element['component']">
                             </component>
                         </div>
 
                         <div v-else>
-                            <component ref="elements" v-model="model[element.config.name]" :validationData="transientData"
+                            <component :class="elementCssClass(element)" ref="elements" v-model="model[element.config.name]" :validationData="transientData"
                                        v-bind="element.config" @submit="submit" @pageNavigate="pageNavigate"
                                        :is="element['component']" v-show="showElement[element.config.name]">
                             </component>
@@ -47,6 +47,7 @@
     import draggable from "vuedraggable";
 
     import FormMultiColumn from "./form-multi-column"
+    import HasColorProperty from "../../mixins/HasColorProperty"
 
     import FormText from "../renderer/form-text";
     import FormButton from "../renderer/form-button";
@@ -63,6 +64,7 @@
 
     export default {
         name: 'FormMultiColumn',
+        mixins: [HasColorProperty],
         props: ["value", "selected", "transientData"],
         components: {
             draggable,

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -83,6 +83,7 @@ import draggable from "vuedraggable";
 import OptionsList from "./inspector/options-list";
 import PageSelect from "./inspector/page-select";
 import ImageUpload from './inspector/image-upload'
+import ColorSelect from "./inspector/color-select"
 
 import FormMultiColumn from "./renderer/form-multi-column";
 import MultiColumn from "./editor/multi-column";
@@ -123,6 +124,7 @@ export default {
     FormRecordList,
     FormImage,
     ImageUpload,
+    ColorSelect,
   },
   data() {
     return {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -39,12 +39,12 @@
               <draggable class="editor-draggable" v-model="config[currentPage]['items']" :options="{group: {name: 'controls'}}">
                 <div class="control-item" :class="{selected: selected === element}" v-for="(element,index) in config[currentPage]['items']" :key="index">
                   <div v-if="element.container">
-                    <component @inspect="inspect" :selected="selected" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
+                    <component :class="eletentCssClass(element)" @inspect="inspect" :selected="selected" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
                     <button class="delete btn btn-danger" @click="deleteItem(index)">x</button>
                   </div>
 
                   <div v-else>
-                    <component v-bind="element.config" :is="element['editor-component']"></component>
+                    <component :class="eletentCssClass(element)" v-bind="element.config" :is="element['editor-component']"></component>
                     <div @click="inspect(element)" class="mask"></div>
                     <button class="delete btn btn-danger" @click="deleteItem(index)">x</button>
                   </div>
@@ -157,7 +157,13 @@ export default {
     }
   },
   methods: {
-    addControl(control) {
+   eletentCssClass(element) {
+     const css = [];
+     element.config.bgcolor ? css.push(element.config.bgcolor) : null;
+     element.config.color ? css.push(element.config.color) : null;
+     return css.join(' ');
+   },
+   addControl(control) {
       this.controls.push(control);
     },
     deleteItem(index) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -39,12 +39,12 @@
               <draggable class="editor-draggable" v-model="config[currentPage]['items']" :options="{group: {name: 'controls'}}">
                 <div class="control-item" :class="{selected: selected === element}" v-for="(element,index) in config[currentPage]['items']" :key="index">
                   <div v-if="element.container">
-                    <component :class="eletentCssClass(element)" @inspect="inspect" :selected="selected" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
+                    <component :class="elementCssClass(element)" @inspect="inspect" :selected="selected" v-model="element.items" v-bind="element.config" :is="element['editor-component']"></component>
                     <button class="delete btn btn-danger" @click="deleteItem(index)">x</button>
                   </div>
 
                   <div v-else>
-                    <component :class="eletentCssClass(element)" v-bind="element.config" :is="element['editor-component']"></component>
+                    <component :class="elementCssClass(element)" v-bind="element.config" :is="element['editor-component']"></component>
                     <div @click="inspect(element)" class="mask"></div>
                     <button class="delete btn btn-danger" @click="deleteItem(index)">x</button>
                   </div>
@@ -84,6 +84,7 @@ import OptionsList from "./inspector/options-list";
 import PageSelect from "./inspector/page-select";
 import ImageUpload from './inspector/image-upload'
 import ColorSelect from "./inspector/color-select"
+import HasColorProperty from "../mixins/HasColorProperty"
 
 import FormMultiColumn from "./renderer/form-multi-column";
 import MultiColumn from "./editor/multi-column";
@@ -107,6 +108,7 @@ import {
 } from "@processmaker/vue-form-elements/src/components";
 
 export default {
+  mixins: [HasColorProperty],
   components: {
     draggable,
     FormInput,
@@ -159,12 +161,6 @@ export default {
     }
   },
   methods: {
-   eletentCssClass(element) {
-     const css = [];
-     element.config.bgcolor ? css.push(element.config.bgcolor) : null;
-     element.config.color ? css.push(element.config.color) : null;
-     return css.join(' ');
-   },
    addControl(control) {
       this.controls.push(control);
     },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -2,14 +2,14 @@
     <div id="renderer-container">
         <div v-for="(element,index) in config[currentPage]['items']" :key="index">
             <div v-if="element.container">
-                <component :class="eletentCssClass(element)" ref="container" selected="selected" :transientData="transientData" v-model="element.items"
+                <component :class="elementCssClass(element)" ref="container" selected="selected" :transientData="transientData" v-model="element.items"
                            @submit="submit"
                            @pageNavigate="pageNavigate" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
 
             <div v-else>
-                <component :class="eletentCssClass(element)" ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit" v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
+                <component :class="elementCssClass(element)" ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit" v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
                            @pageNavigate="pageNavigate" v-bind:name="element.config.name !== undefined ? element.config.name : null" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
@@ -22,6 +22,7 @@
     import Vue from 'vue';
     import * as VueDeepSet from 'vue-deepset';
     import _ from 'lodash';
+    import HasColorProperty from "../mixins/HasColorProperty"
 
     var Parser = require('expr-eval').Parser;
     var csstree = require('css-tree');
@@ -41,6 +42,7 @@
             prop: 'data',
             event: 'update'
         },
+        mixins: [HasColorProperty],
         computed: {
             model() {
                 return this.$deepModel(this.transientData)
@@ -111,12 +113,6 @@
             this.parseCss();
         },
         methods: {
-            eletentCssClass(element) {
-                const css = [];
-                element.config.bgcolor ? css.push(element.config.bgcolor) : null;
-                element.config.color ? css.push(element.config.color) : null;
-                return css.join(' ');
-            },
             submit() {
                 if (this.isValid()) {
                     this.setDefaultValues();

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -2,14 +2,14 @@
     <div id="renderer-container">
         <div v-for="(element,index) in config[currentPage]['items']" :key="index">
             <div v-if="element.container">
-                <component ref="container" selected="selected" :transientData="transientData" v-model="element.items"
+                <component :class="eletentCssClass(element)" ref="container" selected="selected" :transientData="transientData" v-model="element.items"
                            @submit="submit"
                            @pageNavigate="pageNavigate" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
 
             <div v-else>
-                <component ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit" v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
+                <component :class="eletentCssClass(element)" ref="elements" :validationData="transientData" v-model="model[element.config.name]" @submit="submit" v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
                            @pageNavigate="pageNavigate" v-bind:name="element.config.name !== undefined ? element.config.name : null" v-bind="element.config" :is="element['component']">
                 </component>
             </div>
@@ -111,6 +111,12 @@
             this.parseCss();
         },
         methods: {
+            eletentCssClass(element) {
+                const css = [];
+                element.config.bgcolor ? css.push(element.config.bgcolor) : null;
+                element.config.color ? css.push(element.config.color) : null;
+                return css.join(' ');
+            },
             submit() {
                 if (this.isValid()) {
                     this.setDefaultValues();

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -60,7 +60,7 @@ const colorProperty = {
   field: "color",
   config: {
     label: "Text color",
-    helper: "Set the element's fore color",
+    helper: "Set the element's text color",
     options: [
       {
         value: 'text-primary',

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -33,6 +33,10 @@ const bgcolorProperty = {
         content: 'success'
       },
       {
+        value: 'alert alert-danger',
+        content: 'danger'
+      },
+      {
         value: 'alert alert-warning',
         content: 'warning'
       },
@@ -69,6 +73,10 @@ const colorProperty = {
       {
         value: 'text-success',
         content: 'success'
+      },
+      {
+        value: 'text-danger',
+        content: 'danger'
       },
       {
         value: 'text-warning',

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -201,6 +201,44 @@ export default [
                         helper: "Help text is meant to provide additional guidance on the field's value"
                     }
                 },
+                {
+                    type: "ColorSelect",
+                    field: "bgcolor",
+                    config: {
+                        label: "Background color",
+                        helper: "Set the element's background color",
+                        options: [
+                            {
+                                value: 'alert alert-primary',
+                                content: 'primary'
+                            },
+                            {
+                                value: 'alert alert-secondary',
+                                content: 'secondary'
+                            },
+                            {
+                                value: 'alert alert-success',
+                                content: 'success'
+                            },
+                            {
+                                value: 'alert alert-warning',
+                                content: 'warning'
+                            },
+                            {
+                                value: 'alert alert-info',
+                                content: 'info'
+                            },
+                            {
+                                value: 'alert alert-light',
+                                content: 'light'
+                            },
+                            {
+                                value: 'alert alert-dark',
+                                content: 'dark'
+                            },
+                        ]
+                    }
+                },
             ]
         },
     },

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -13,6 +13,83 @@ import {
     FormDatePicker,
 } from "@processmaker/vue-form-elements/src/components";
 
+const bgcolorProperty = {
+  type: "ColorSelect",
+  field: "bgcolor",
+  config: {
+    label: "Background color",
+    helper: "Set the element's background color",
+    options: [
+      {
+        value: 'alert alert-primary',
+        content: 'primary'
+      },
+      {
+        value: 'alert alert-secondary',
+        content: 'secondary'
+      },
+      {
+        value: 'alert alert-success',
+        content: 'success'
+      },
+      {
+        value: 'alert alert-warning',
+        content: 'warning'
+      },
+      {
+        value: 'alert alert-info',
+        content: 'info'
+      },
+      {
+        value: 'alert alert-light',
+        content: 'light'
+      },
+      {
+        value: 'alert alert-dark',
+        content: 'dark'
+      },
+    ]
+  }
+};
+const colorProperty = {
+  type: "ColorSelect",
+  field: "color",
+  config: {
+    label: "Fore color",
+    helper: "Set the element's fore color",
+    options: [
+      {
+        value: 'text-primary',
+        content: 'primary'
+      },
+      {
+        value: 'text-secondary',
+        content: 'secondary'
+      },
+      {
+        value: 'text-success',
+        content: 'success'
+      },
+      {
+        value: 'text-warning',
+        content: 'warning'
+      },
+      {
+        value: 'text-info',
+        content: 'info'
+      },
+      {
+        value: 'text-light',
+        content: 'light'
+      },
+      {
+        value: 'text-dark',
+        content: 'dark'
+      },
+    ]
+  }
+};
+
 export default [
     {
         builderComponent: FormText,
@@ -118,6 +195,8 @@ export default [
                         ]
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         }
     },
@@ -201,44 +280,8 @@ export default [
                         helper: "Help text is meant to provide additional guidance on the field's value"
                     }
                 },
-                {
-                    type: "ColorSelect",
-                    field: "bgcolor",
-                    config: {
-                        label: "Background color",
-                        helper: "Set the element's background color",
-                        options: [
-                            {
-                                value: 'alert alert-primary',
-                                content: 'primary'
-                            },
-                            {
-                                value: 'alert alert-secondary',
-                                content: 'secondary'
-                            },
-                            {
-                                value: 'alert alert-success',
-                                content: 'success'
-                            },
-                            {
-                                value: 'alert alert-warning',
-                                content: 'warning'
-                            },
-                            {
-                                value: 'alert alert-info',
-                                content: 'info'
-                            },
-                            {
-                                value: 'alert alert-light',
-                                content: 'light'
-                            },
-                            {
-                                value: 'alert alert-dark',
-                                content: 'dark'
-                            },
-                        ]
-                    }
-                },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -306,6 +349,8 @@ export default [
                         helper: "List of options available in the select drop down"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -361,6 +406,8 @@ export default [
                         helper: "List of options available in the select drop down"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -414,6 +461,8 @@ export default [
                         helper: "Should the checkbox be checked by default"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -484,6 +533,8 @@ export default [
                         helper: "Help text is meant to provide additional guidance on the field's value"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -529,6 +580,8 @@ export default [
                         helper: "The placeholder is what is shown in the field when no value is provided yet"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -741,8 +794,9 @@ export default [
                         label: "Show If:",
                         helper: "Hide this control unless the following expression is true"
                     }
-                }
-
+                },
+                bgcolorProperty,
+                colorProperty,
             ]
         },
     },
@@ -807,6 +861,8 @@ export default [
                         helper: "The form to use for adding/editing records"
                     }
                 },
+                bgcolorProperty,
+                colorProperty,
             ]
 
         },

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -59,7 +59,7 @@ const colorProperty = {
   type: "ColorSelect",
   field: "color",
   config: {
-    label: "Fore color",
+    label: "Text color",
     helper: "Set the element's fore color",
     options: [
       {

--- a/src/mixins/HasColorProperty.js
+++ b/src/mixins/HasColorProperty.js
@@ -1,0 +1,12 @@
+
+export default {
+  methods: {
+    elementCssClass(element) {
+      const css = [];
+      element.config.bgcolor ? css.push(element.config.bgcolor) : null;
+      element.config.color ? css.push(element.config.color) : null;
+      return css.join(' ');
+    },
+  }
+};
+


### PR DESCRIPTION
This PR includes:

- Add a control to select colors
- Add properties bgcolor and color for the controls
- Add the additional properties to the form templates.

Color choose:
![image](https://user-images.githubusercontent.com/8028650/52574211-32418100-2df2-11e9-8f7c-6edd18f34ffe.png)
Design mode:
![image](https://user-images.githubusercontent.com/8028650/52574170-15a54900-2df2-11e9-8f80-df431c55137f.png)
Preview:
![image](https://user-images.githubusercontent.com/8028650/52574186-248bfb80-2df2-11e9-976f-aca8f7f23f45.png)

Implements: #52 
