### PR TITLE
Import missing ImageUpload component

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ import FormMultiColumn from './renderer/form-multi-column'
 import FormRecordList from './renderer/form-record-list'
 import FormText from './renderer/form-text'
 import ControlsConfiguration from '../form-builder-controls'
+import ImageUpload from './inspector/image-upload.vue'
 
 let editor = {
     MultiColumn


### PR DESCRIPTION
When using the latest `develop` (`0.7.0`) in modeler, an error with thrown due to a missing import:
```
Uncaught ReferenceError: ImageUpload is not defined
```

This PR fixes that issue.

Related issue: https://github.com/ProcessMaker/modeler/issues/221 (Inspector Accordion).