### PR TITLE
Add ids to elements so custom css can use them

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -27,7 +27,7 @@
                 <button class="delete btn btn-sm btn-danger" @click="deleteItem(index, row)">x</button>
               </div>
 
-              <div v-else>
+              <div v-else :id="element.config.name ? element.config.name : undefined">
                 <component
                   :class="elementCssClass(element)"
                   v-bind="element.config"

--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -19,17 +19,19 @@
               </template>
 
               <template v-else>
-                <component
-                  :class="elementCssClass(element)"
-                  ref="elements"
-                  v-model="model[element.config.name]"
-                  :validationData="transientData"
-                  @submit="submit"
-                  @pageNavigate="pageNavigate"
-                  v-bind="element.config"
-                  :is="element['component']"
-                  v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
-                ></component>
+                <div :id="element.config.name ? element.config.name : undefined">
+                  <component
+                    :class="elementCssClass(element)"
+                    ref="elements"
+                    v-model="model[element.config.name]"
+                    :validationData="transientData"
+                    @submit="submit"
+                    @pageNavigate="pageNavigate"
+                    v-bind="element.config"
+                    :is="element['component']"
+                    v-show="showElement[element.config.name] !== undefined ? showElement[element.config.name] : true"
+                  ></component>
+                </div>
               </template>
             </div>
           </div>

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -20,7 +20,7 @@
         ></component>
       </div>
 
-      <div v-else>
+      <div v-else :id="element.config.name ? element.config.name : undefined">
         <component
           :class="elementCssClass(element)"
           ref="elements"


### PR DESCRIPTION
Fixes #88 

Brings back the missing IDs on rendered elements so the custom CSS editor can use them