### PR TITLE
Implement javascript evaluation for computed properties

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -104,13 +104,12 @@ export default {
     },
     transientData: {
       handler: function() {
-        let that = this;
-        if (that.computed) {
-          that.computed.forEach(prop => {
+        if (this.computed) {
+          this.computed.forEach(prop => {
             let value;
             try {
               if (prop.type==='expression') {
-                value = Parser.evaluate(prop.formula, that.transientData);
+                value = Parser.evaluate(prop.formula, this.transientData);
               } else if(prop.type==='javascript') {
                 var func = new Function(prop.formula);
                 value = this.transientData[prop.property] = func.bind(JSON.parse(JSON.stringify(this.transientData)))();
@@ -118,14 +117,14 @@ export default {
             } catch (e) {
               value = String(e);
             }
-            this.$set(that.transientData, prop.property, value);
-            this.$set(that.data, prop.property, value);
+            this.$set(this.transientData, prop.property, value);
+            this.$set(this.data, prop.property, value);
           });
         }
         // Only emit the update message if transientData does NOT equal this.data
         // Instead of deep object property comparison, we'll just compare the JSON representations of both
-        if (JSON.stringify(that.transientData) != JSON.stringify(that.data)) {
-          that.$emit("update", that.transientData);
+        if (JSON.stringify(this.transientData) != JSON.stringify(this.data)) {
+          this.$emit("update", this.transientData);
           return;
         }
       },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -112,7 +112,8 @@ export default {
               if (prop.type==='expression') {
                 value = Parser.evaluate(prop.formula, that.transientData);
               } else if(prop.type==='javascript') {
-                value = this.javascriptEval(prop.formula, that.transientData);
+                var func = new Function(prop.formula);
+                value = this.transientData[prop.property] = func.bind(JSON.parse(JSON.stringify(this.transientData)))();
               }
             } catch (e) {
               value = String(e);
@@ -138,15 +139,6 @@ export default {
     this.parseCss();
   },
   methods: {
-    javascriptEval() {
-      let $key;
-      const expression = [];
-      for($key of Object.keys(arguments[1])) {
-        expression.push('var ' + $key + '=arguments[1][' + JSON.stringify($key) + ']');
-      }
-      expression.push(arguments[0]);
-      return eval(expression.join("\n"));
-    },
     submit() {
       if (this.isValid()) {
         this.setDefaultValues();


### PR DESCRIPTION
This PR changes the javascript evaluation in computed properties to use new Function and using .**bind**() function to put the data context into **this**. This way the properties should be referenced as follows:

```
  return this.a + this.b
```

![image](https://user-images.githubusercontent.com/8028650/53910014-3fd0dc00-4029-11e9-8fb7-3a5ed31a0fb5.png)
