### PR TITLE
Make bootstrap an external/peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.1",
     "@processmaker/vue-form-elements": "^0.5.0",
-    "bootstrap": "^4.1.3",
     "css-tree": "^1.0.0-alpha.29",
     "expr-eval": "^1.2.2",
     "monaco-editor-webpack-plugin": "^1.7.0",
@@ -44,9 +43,12 @@
     "@vue/cli-service": "^3.0.0-rc.9",
     "@vue/test-utils": "^1.0.0-beta.20",
     "babel-core": "7.0.0-bridge.0",
-    "bootstrap-vue": "^2.0.0-rc.11",
     "vue-json-pretty": "^1.4.0",
     "vue-template-compiler": "^2.5.16"
+  },
+  "peerDependencies": {
+    "bootstrap": "^4.1.3",
+    "bootstrap-vue": "^2.0.0-rc.11"
   },
   "eslintConfig": {
     "root": true,

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,6 +7,9 @@ module.exports = {
       new MonocoEditorPlugin({
         languages: ['javascript', 'typescript', 'css']
       })
-    ]
+    ],
+    externals: {
+      subtract: ['bootstrap']
+    }
   }
 }


### PR DESCRIPTION
Currently, bootstrap was included in the bundle output. This PR makes it an external dependency so it plays well with the environment where it's used (to avoid conflicts with bootstrap versions). This change is required for the `switch` property on the `b-form-checkbox` component to actually show a switch (required for https://github.com/ProcessMaker/modeler/pull/278).